### PR TITLE
Fix Hypothesis integration

### DIFF
--- a/plugins/python/ChangeLog.txt
+++ b/plugins/python/ChangeLog.txt
@@ -1,0 +1,10 @@
+v0.0.3:
+- bugfixes:
+  - fixed hypothesis integration
+  - added testcode decorator: test_no_inject
+
+v0.0.2:
+- update to python 3.9
+
+v0.0.1:
+- initial version

--- a/plugins/python/ReadMe.md
+++ b/plugins/python/ReadMe.md
@@ -10,6 +10,8 @@ see ServerCodeTest docu.
 * `test(points:Union[int,float]=0, description:str="")`
   * registers the following function as a test function.
   * injects the *given function* as first argument
+* `test_no_inject(points:Union[int,float]=0, description:str="")`
+  * registers the following function as a test function.
 * `check_args(points:Union[int,float]=0, description:str="")`
   * registers the following function as an argument check function.
   * will be called for each call to the *given function* and injects the arguments of the calls.
@@ -34,18 +36,32 @@ unittests need to be prefixed with `test_`
 ```python
 set_function("sort") 
 
+###
 @test(points=1, description="Test 1")
 def test_1(fn):
   assert [] == fn([])
 
+###
 @test(points=1, description="Test 2")
 def test_2(fn):
   assert [] == user.sort([])
 
+###
+from hypothesis import given, example
+import hypothesis.strategies as st
+
+@test_no_inject(points=2, description="Test 3")
+@given(x=st.lists(st.integers()))
+@example(x=[])
+def test_3(args):
+  assert sorted(args) == user.sort(args)
+
+##################################
 @check_args(points=1, description="CA 1")
 def ca_1(lst:list, *args, **args):
   assert lst==[]
 
+###
 @check_args(points=1, description="CA 2")
 def ca_2(lst:list, *args, **args):
   assert len(lst) == 1
@@ -53,3 +69,7 @@ def ca_2(lst:list, *args, **args):
 As seen above, the student code will be implicitly imported as module `user`.
 
 If `check_args` is used a function needs to be set with `set_function`.
+
+## dev notes
+### updates:
+* don't forget to increase version in plugin.json

--- a/plugins/python/container/fn/execute/sct_test.py
+++ b/plugins/python/container/fn/execute/sct_test.py
@@ -3,7 +3,12 @@ Functions:
 - set_function(name)
 Decorators:
 - test
+- test_no_inject
 - check_args
+
+Dev Note:
+All decorators and functions must be imported from the file.
+=> plugin.py filter_source 
 """
 
 import itertools
@@ -12,7 +17,7 @@ def set_function(name:str):
     Hook.init(name)
 
 
-def test(points:int=0, description:str=""):
+def test(points:int=0, description:str="", inject_fn:bool=True):
     """
 Add Testfunction:
 - points: number of points if test is successful
@@ -28,7 +33,12 @@ def test_1(fn):
 def test_2(fn):
     assert True
 """
-    return Test.decorator(description, points)
+    return Test.decorator(description, points, not inject_fn)
+
+def test_no_inject(points:int=0, description:str=""):
+    """Same as test but doesn't inject function as first argument
+    """ 
+    return test(points, description, False)
 
 
 def check_args(points:int=0, description:str=""):
@@ -111,13 +121,14 @@ class Base:
         cls.registered.append((fn, description, points))
 
     @classmethod
-    def decorator(cls, description="", points=0):
+    def decorator(cls, description="", points=0, no_args=False):
         def fn_wrapper(fn):
-            cls.register(fn, description, points)
-
             def wrapper(*args, **kwargs):
-                return fn(*args, **kwargs)
-
+                if no_args:
+                    return fn()
+                else:
+                    return fn(*args, **kwargs)
+            cls.register(wrapper, description, points)
             return wrapper
 
         return fn_wrapper

--- a/plugins/python/container/plugin.py
+++ b/plugins/python/container/plugin.py
@@ -93,7 +93,7 @@ class Plugin:
 
     def _write_files(self, _dir:str, data:dict):
         code = filter_source(data["code"], "def test_dummy():\n assert True")
-        test = filter_source(data["test"], "from sct_test import test, check_args, set_function")
+        test = filter_source(data["test"], "from sct_test import test, test_no_inject, check_args, set_function")
         with open(os.path.join(_dir, "sct_user.py"), "w") as file:
             file.write(code)
         with open(os.path.join(_dir, "sct_compare.py"), "w") as file:

--- a/plugins/python/plugin.json
+++ b/plugins/python/plugin.json
@@ -2,7 +2,7 @@
     
     "uid":"sct_python_3",
     "name":"Python 3",
-    "version": "0.0.1",
+    "version": "0.0.3",
     "author":"Stefan Schweizer",
     "description":""
 }


### PR DESCRIPTION
Current behaviour:
decorator `python @test` causes an error, because it injected the function (set_function) as first argument.
If Hypothesis was used, this couldn't be avoided
-> *fn* takes 0 positional arguments but 1 was given

New Behaviour:
User Code:
```python
def sort(lst: list):
    return sorted(lst)
```
Test Code:
```python
from hypothesis import given, example
import hypothesis.strategies as st

@test_no_inject(points=2, description="Test 3")
@given(x=st.lists(st.integers()))
@example(x=[])
def test_3(args):
  assert sorted(args) == user.sort(args)
```
